### PR TITLE
Add skeleton cli structure for gitflow-rs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@ Cargo.lock
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Added by cargo
+
+/target

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "gitflow-rs"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+clap = { version = "4.5.31", features = ["derive"] }
+git2 = "0.20.0"
+log = "0.4.26"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,28 @@
+use clap::{Parser, Subcommand};
+
+/// GitFlow CLI for managing GitHub development workflow
+#[derive(Debug, Parser)]
+#[clap(name = "gitflow", about = "A CLI to manage GitHub development workflow", version, author)]
+pub struct Cli {
+    /// Verbose output (use multiple for increased verbosity)
+    #[clap(short, long, action = clap::ArgAction::Count)]
+    pub verbose: u8,
+    
+    /// The subcommand to execute
+    #[clap(subcommand)]
+    pub command: Commands,
+}
+
+/// GitFlow CLI subcommands
+#[derive(Debug, Subcommand)]
+pub enum Commands {
+    /// Create a new branch based on the current branch or specified parent
+    New {
+        /// Name of the new branch
+        name: String,
+        
+        /// Parent branch to use (defaults to current branch)
+        #[clap(long)]
+        parent: Option<String>,
+    },
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,41 @@
+mod cli;
+
+use clap::Parser;
+use git2::Repository;
+use std::result::Result;
+use log::error;
+
+/// The main entry point of the application
+fn main() {
+    // Parse command line arguments
+    let cli = cli::Cli::parse();
+    
+    // Run the application and handle any errors
+    if let Err(e) = run(cli) {
+        error!("Error: {}", e);
+        std::process::exit(1);
+    }
+}
+
+/// Runs the application logic based on the parsed CLI arguments
+///
+/// # Arguments
+///
+/// * `cli` - A struct containing the parsed command line arguments
+///
+/// # Returns
+///
+/// * `Result<(), Box<dyn std::error::Error>>` - Returns an empty Ok result on success, or an error on failure
+fn run(cli: cli::Cli) -> Result<(), Box<dyn std::error::Error>> {    
+    // Open the git repository located at the current directory
+    let _repo = Repository::open(".")?;
+    
+    // Handle the appropriate command based on the parsed CLI arguments
+    match cli.command {
+        cli::Commands::New { name: _, parent: _} => {
+            // TODO: Implement the logic for the 'New' command
+        }
+    }
+    
+    Ok(())
+}


### PR DESCRIPTION
- Add a subcommand `new`
- add necessary crates to get the cli to build