### PR TITLE
implement subcommand: cascade

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [dependencies]
 clap = { version = "4.5.31", features = ["derive"] }
+colored = "3.0.0"
 git2 = "0.20.0"
 log = "0.4.26"
 thiserror = "2.0.11"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -44,4 +44,10 @@ pub enum Commands {
         #[clap(long)]
         parent: Option<String>,
     },
+
+    Cascade {
+        /// Confirm all merges without prompting
+        #[clap(short, long)]
+        yes: bool,
+    },
 }

--- a/src/commands/cascade.rs
+++ b/src/commands/cascade.rs
@@ -1,0 +1,91 @@
+use crate::error::{GitFlowError, Result};
+use crate::git;
+use crate::utils::prompt_confirmation;
+use git2::Repository;
+use log::{info, warn};
+use std::collections::HashMap;
+
+/// Handle the 'cascade' command to merge branches recursively
+///
+/// # Arguments
+///
+/// * `repo` - A reference to the Git repository
+/// * `yes` - A boolean flag to confirm all merges without prompting
+///
+/// # Returns
+///
+/// * `Result<()>` - Returns an empty Ok result on success, or an error on failure
+pub fn handle_cascade(repo: &Repository, yes: bool) -> Result<()> {
+    let branch_tree = git::get_branch_tree(repo)?;
+
+    // Show the planned merges
+    info!("Planning to perform the following merges:");
+    for (parent, children) in &branch_tree {
+        for child in children {
+            info!("  {} -> {}", parent, child);
+        }
+    }
+
+    // Ask for confirmation unless --yes flag is provided
+    if !yes && !prompt_confirmation("Proceed with merges?")? {
+        return Err(GitFlowError::Aborted(
+            "Merge operation cancelled".to_string(),
+        ));
+    }
+
+    let mut processed = HashMap::new();
+
+    // Process each root branch
+    let root_branches = git::find_root_branches(&branch_tree);
+    for branch in root_branches {
+        merge_recursive(repo, &branch, &branch_tree, &mut processed)?;
+    }
+
+    info!("Cascade merge completed successfully");
+    Ok(())
+}
+
+/// Recursively merge branches based on the branch hierarchy
+///
+/// # Arguments
+///
+/// * `repo` - A reference to the Git repository
+/// * `branch` - The current branch to process
+/// * `branch_tree` - A hashmap representing the branch tree
+/// * `processed` - A hashmap to keep track of processed branches
+///
+/// # Returns
+///
+/// * `Result<()>` - Returns an empty Ok result on success, or an error on failure
+fn merge_recursive(
+    repo: &Repository,
+    branch: &str,
+    branch_tree: &HashMap<String, Vec<String>>,
+    processed: &mut HashMap<String, bool>,
+) -> Result<()> {
+    if processed.contains_key(branch) {
+        return Ok(());
+    }
+
+    // Process this branch
+    processed.insert(branch.to_string(), true);
+
+    // Get children of this branch
+    if let Some(children) = branch_tree.get(branch) {
+        for child in children {
+            // Merge this branch into child
+            match git::merge_branch(repo, branch, child) {
+                Ok(_) => {}
+                Err(e) => {
+                    warn!("Failed to merge {} into {}: {}", branch, child, e);
+                    // Continue with other branches even if one fails
+                }
+            }
+
+            // Recursively process children
+            merge_recursive(repo, child, branch_tree, processed)?;
+        }
+    }
+
+    Ok(())
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,1 +1,2 @@
+pub mod cascade;
 pub mod create;

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,4 @@
+use std::io;
 use thiserror::Error;
 
 /// Custom error types for GitFlow
@@ -6,11 +7,14 @@ pub enum GitFlowError {
     #[error("Git error: {0}")]
     Git(#[from] git2::Error),
 
+    #[error("Operation aborted: {0}")]
+    Aborted(String),
+
     #[error("Branch not found: {0}")]
     BranchNotFound(String),
 
-    #[error("Unknown error: {0}")]
-    Unknown(String),
+    #[error("IO error: {0}")]
+    Io(#[from] io::Error),
 }
 
 /// Result type alias to simplify function signatures

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,18 +1,18 @@
-use std::io;
 use thiserror::Error;
+use std::io;
 
 /// Custom error types for GitFlow
 #[derive(Error, Debug)]
 pub enum GitFlowError {
     #[error("Git error: {0}")]
     Git(#[from] git2::Error),
-
+    
     #[error("Operation aborted: {0}")]
     Aborted(String),
-
+    
     #[error("Branch not found: {0}")]
     BranchNotFound(String),
-
+    
     #[error("IO error: {0}")]
     Io(#[from] io::Error),
 }

--- a/src/git/branch.rs
+++ b/src/git/branch.rs
@@ -4,6 +4,14 @@ use log::{debug, info};
 use std::collections::{HashMap, HashSet};
 
 /// Build a tree of branches showing parent-child relationships
+///
+/// # Arguments
+///
+/// * `repo` - A reference to the Git repository
+///
+/// # Returns
+///
+/// * `Result<HashMap<String, Vec<String>>>` - Returns a hashmap representing the branch tree, or an error if it fails
 pub fn get_branch_tree(repo: &Repository) -> Result<HashMap<String, Vec<String>>> {
     let mut tree = HashMap::new();
     let branches = repo.branches(Some(BranchType::Local))?;
@@ -121,6 +129,17 @@ pub fn create_new_branch(repo: &Repository, name: &str, parent: Option<&str>) ->
 }
 
 /// Check if there's a more direct parent between potential parent and child
+///
+/// # Arguments
+///
+/// * `all_branches` - A list of all branch names
+/// * `parent` - The potential parent branch name
+/// * `child` - The potential child branch name
+/// * `repo` - A reference to the Git repository
+///
+/// # Returns
+///
+/// * `Result<bool>` - Returns true if there is a more direct parent, false otherwise
 pub fn is_direct_parent_child(
     all_branches: &[String],
     parent: &str,
@@ -148,6 +167,16 @@ pub fn is_direct_parent_child(
 }
 
 /// Check if commit is a descendant of potential_ancestor
+///
+/// # Arguments
+///
+/// * `repo` - A reference to the Git repository
+/// * `commit` - The commit to check
+/// * `potential_ancestor` - The potential ancestor commit
+///
+/// # Returns
+///
+/// * `Result<bool>` - Returns true if the commit is a descendant, false otherwise
 pub fn is_descendant_of(
     repo: &Repository,
     commit: &Commit,
@@ -175,6 +204,14 @@ pub fn is_descendant_of(
 }
 
 /// Find root branches (those without parents)
+///
+/// # Arguments
+///
+/// * `branch_tree` - A hashmap representing the branch tree
+///
+/// # Returns
+///
+/// * `Vec<String>` - Returns a vector of root branch names
 pub fn find_root_branches(branch_tree: &HashMap<String, Vec<String>>) -> Vec<String> {
     let all_children: HashSet<String> = branch_tree.values().flatten().cloned().collect();
 
@@ -186,6 +223,15 @@ pub fn find_root_branches(branch_tree: &HashMap<String, Vec<String>>) -> Vec<Str
 }
 
 /// Checkout a branch by name
+///
+/// # Arguments
+///
+/// * `repo` - A reference to the Git repository
+/// * `branch_name` - The name of the branch to checkout
+///
+/// # Returns
+///
+/// * `Result<()>` - Returns an empty Ok result on success, or an error on failure
 pub fn checkout_branch(repo: &Repository, branch_name: &str) -> Result<()> {
     let obj = repo.revparse_single(&format!("refs/heads/{}", branch_name))?;
     repo.checkout_tree(&obj, None)?;

--- a/src/git/branch.rs
+++ b/src/git/branch.rs
@@ -1,6 +1,51 @@
 use crate::error::{GitFlowError, Result};
-use git2::{BranchType, Repository};
-use log::info;
+use git2::{BranchType, Commit, Repository};
+use log::{debug, info};
+use std::collections::{HashMap, HashSet};
+
+/// Build a tree of branches showing parent-child relationships
+pub fn get_branch_tree(repo: &Repository) -> Result<HashMap<String, Vec<String>>> {
+    let mut tree = HashMap::new();
+    let branches = repo.branches(Some(BranchType::Local))?;
+
+    // First pass: collect all branches
+    let mut all_branches = Vec::new();
+    for branch_result in branches {
+        let (branch, _) = branch_result?;
+        let name = branch
+            .name()?
+            .ok_or_else(|| {
+                GitFlowError::Git(git2::Error::from_str("Invalid UTF-8 in branch name"))
+            })?
+            .to_string();
+
+        all_branches.push(name);
+    }
+
+    // Second pass: build the tree
+    for branch_name in &all_branches {
+        let commit = repo.revparse_single(branch_name)?.peel_to_commit()?;
+
+        for other_branch in &all_branches {
+            if branch_name == other_branch {
+                continue;
+            }
+
+            let other_commit = repo.revparse_single(other_branch)?.peel_to_commit()?;
+
+            // Check if other_branch is a direct descendant of branch_name
+            if is_descendant_of(repo, &other_commit, &commit)?
+                && !is_direct_parent_child(&all_branches, branch_name, other_branch, repo)?
+            {
+                tree.entry(branch_name.clone())
+                    .or_insert_with(Vec::new)
+                    .push(other_branch.clone());
+            }
+        }
+    }
+
+    Ok(tree)
+}
 
 /// Get the current branch name from the Git repository
 ///
@@ -14,14 +59,14 @@ use log::info;
 pub fn get_current_branch(repo: &Repository) -> Result<String> {
     // Get the reference to the current HEAD
     let head = repo.head()?;
-    
+
     // Check if HEAD is pointing to a branch
     if !head.is_branch() {
         return Err(GitFlowError::Git(git2::Error::from_str(
             "HEAD is not a branch (detached HEAD state)",
         )));
     }
-    
+
     // Get the branch name from the HEAD reference
     head.shorthand()
         .ok_or_else(|| GitFlowError::Git(git2::Error::from_str("Could not get branch name")))
@@ -42,33 +87,109 @@ pub fn get_current_branch(repo: &Repository) -> Result<String> {
 pub fn create_new_branch(repo: &Repository, name: &str, parent: Option<&str>) -> Result<()> {
     // Check if branch already exists
     if repo.find_branch(name, BranchType::Local).is_ok() {
-        return Err(GitFlowError::Git(git2::Error::from_str(
-            &format!("Branch '{}' already exists", name),
-        )));
+        return Err(GitFlowError::Git(git2::Error::from_str(&format!(
+            "Branch '{}' already exists",
+            name
+        ))));
     }
-    
+
     // Determine the parent branch name
     let parent_branch_name = match parent {
         Some(branch) => branch.to_string(),
         None => get_current_branch(repo)?,
     };
-    
+
     // Find the parent branch
-    let parent_branch = repo.find_branch(&parent_branch_name, BranchType::Local)
+    let parent_branch = repo
+        .find_branch(&parent_branch_name, BranchType::Local)
         .map_err(|_| GitFlowError::BranchNotFound(parent_branch_name.clone()))?;
-        
+
     // Get the commit to branch from
     let commit = parent_branch.get().peel_to_commit()?;
-    
+
     // Create the new branch
     repo.branch(name, &commit, false)?;
-    
+
     // Checkout the new branch
     let obj = repo.revparse_single(&format!("refs/heads/{}", name))?;
     repo.checkout_tree(&obj, None)?;
     repo.set_head(&format!("refs/heads/{}", name))?;
-    
+
     // Log the branch creation and switch
     info!("Created and switched to branch: {}", name);
+    Ok(())
+}
+
+/// Check if there's a more direct parent between potential parent and child
+pub fn is_direct_parent_child(
+    all_branches: &[String],
+    parent: &str,
+    child: &str,
+    repo: &Repository,
+) -> Result<bool> {
+    let parent_commit = repo.revparse_single(parent)?.peel_to_commit()?;
+    let child_commit = repo.revparse_single(child)?.peel_to_commit()?;
+
+    // Check all other branches to see if any are between parent and child
+    for other in all_branches {
+        if other != parent && other != child {
+            let other_commit = repo.revparse_single(other)?.peel_to_commit()?;
+
+            // If other is between parent and child, this is not a direct relationship
+            if is_descendant_of(repo, &other_commit, &parent_commit)?
+                && is_descendant_of(repo, &child_commit, &other_commit)?
+            {
+                return Ok(false);
+            }
+        }
+    }
+
+    Ok(true)
+}
+
+/// Check if commit is a descendant of potential_ancestor
+pub fn is_descendant_of(
+    repo: &Repository,
+    commit: &Commit,
+    potential_ancestor: &Commit,
+) -> Result<bool> {
+    if commit.id() == potential_ancestor.id() {
+        return Ok(false); // Same commit, not a descendant
+    }
+
+    let mut revwalk = repo.revwalk()?;
+    revwalk.set_sorting(git2::Sort::TIME)?;
+
+    // Push the commit's ancestors
+    revwalk.push(commit.id())?;
+
+    // Look for the potential ancestor
+    for ancestor_id in revwalk {
+        let ancestor_id = ancestor_id?;
+        if ancestor_id == potential_ancestor.id() {
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
+}
+
+/// Find root branches (those without parents)
+pub fn find_root_branches(branch_tree: &HashMap<String, Vec<String>>) -> Vec<String> {
+    let all_children: HashSet<String> = branch_tree.values().flatten().cloned().collect();
+
+    branch_tree
+        .keys()
+        .filter(|branch| !all_children.contains(*branch))
+        .cloned()
+        .collect()
+}
+
+/// Checkout a branch by name
+pub fn checkout_branch(repo: &Repository, branch_name: &str) -> Result<()> {
+    let obj = repo.revparse_single(&format!("refs/heads/{}", branch_name))?;
+    repo.checkout_tree(&obj, None)?;
+    repo.set_head(&format!("refs/heads/{}", branch_name))?;
+    debug!("Checked out branch: {}", branch_name);
     Ok(())
 }

--- a/src/git/merge.rs
+++ b/src/git/merge.rs
@@ -1,0 +1,136 @@
+use crate::error::{GitFlowError, Result};
+use crate::git::branch::{checkout_branch, get_current_branch};
+use crate::git::status::get_repo_status;
+use git2::{ErrorCode, MergeOptions, Repository};
+use log::{info, warn};
+
+/// Merge one branch into another with proper conflict handling.
+/// 
+/// # Arguments
+/// 
+/// * `repo` - A reference to the Git repository.
+/// * `from` - The source branch name.
+/// * `to` - The target branch name.
+/// 
+/// # Returns
+/// 
+/// * `Result<()>` - Returns an empty Ok result on success, or an error on failure.
+pub fn merge_branch(repo: &Repository, from: &str, to: &str) -> Result<()> {
+    info!("Merging {} into {}", from, to);
+
+    // Check if there are uncommitted changes
+    let status = get_repo_status(repo)?;
+    if !status.is_empty() {
+        return Err(GitFlowError::Aborted(
+            "There are uncommitted changes. Please commit or stash them first.".to_string(),
+        ));
+    }
+
+    // Get the current branch to restore later if needed
+    let original_branch = get_current_branch(repo)?;
+
+    // Checkout the target branch
+    checkout_branch(repo, to)?;
+
+    // Find the annotated commit to merge
+    let reference = repo.find_reference(&format!("refs/heads/{}", from))?;
+    let annotated_commit = repo.reference_to_annotated_commit(&reference)?;
+
+    // Prepare merge options
+    let mut merge_options = MergeOptions::new();
+    merge_options.fail_on_conflict(false);
+
+    // Do the merge analysis
+    let analysis = repo.merge_analysis(&[&annotated_commit])?;
+
+    // Handle different merge scenarios
+    if analysis.0.is_up_to_date() {
+        info!("Already up-to-date");
+    } else if analysis.0.is_fast_forward() {
+        // Fast-forward merge
+        let commit = repo.find_annotated_commit(annotated_commit.id())?;
+
+        info!("Fast-forward merge");
+
+        // Do the fast-forward
+        let mut target_ref = repo.find_reference(&format!("refs/heads/{}", to))?;
+        target_ref.set_target(commit.id(), "Fast-forward")?;
+        repo.checkout_tree(&repo.find_object(commit.id(), None)?, None)?;
+        repo.set_head(&target_ref.name().unwrap())?;
+    } else {
+        // Normal merge
+        let sig = repo.signature()?;
+
+        // Perform the merge
+        let result = repo.merge(&[&annotated_commit], Some(&mut merge_options), None);
+
+        if let Err(e) = result {
+            if e.code() == ErrorCode::Conflict {
+                // Handle merge conflicts
+                warn!("Merge conflicts detected");
+
+                // Abort the merge
+                repo.cleanup_state()?;
+
+                // Restore the original branch
+                if original_branch != to {
+                    checkout_branch(repo, &original_branch)?;
+                }
+
+                return Err(GitFlowError::Aborted(format!(
+                    "Merge conflicts detected between {} and {}. Please resolve manually.",
+                    from, to
+                )));
+            } else {
+                return Err(GitFlowError::Git(e));
+            }
+        }
+
+        // Get the index with conflicts (if any)
+        let mut index = repo.index()?;
+
+        if index.has_conflicts() {
+            // Abort the merge if there are conflicts
+            repo.cleanup_state()?;
+
+            // Restore the original branch
+            if original_branch != to {
+                checkout_branch(repo, &original_branch)?;
+            }
+
+            return Err(GitFlowError::Aborted(format!(
+                "Merge conflicts detected between {} and {}. Please resolve manually.",
+                from, to
+            )));
+        }
+
+        // No conflicts, create the commit
+        let tree_id = index.write_tree()?;
+        let tree = repo.find_tree(tree_id)?;
+
+        // Get parent commits
+        let head_commit = repo.head()?.peel_to_commit()?;
+        let merged_commit = repo.find_commit(annotated_commit.id())?;
+
+        // Create the merge commit
+        repo.commit(
+            Some("HEAD"),
+            &sig,
+            &sig,
+            &format!("Merge branch '{}' into '{}'", from, to),
+            &tree,
+            &[&head_commit, &merged_commit],
+        )?;
+
+        // Cleanup the merge state
+        repo.cleanup_state()?;
+    }
+
+    // Return to the original branch if needed
+    if original_branch != to {
+        checkout_branch(repo, &original_branch)?;
+    }
+
+    info!("Successfully merged {} into {}", from, to);
+    Ok(())
+}

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -1,3 +1,7 @@
 pub mod branch;
+pub mod merge;
+pub mod status;
 
-pub use branch::create_new_branch;
+pub use branch::{create_new_branch, find_root_branches, get_branch_tree};
+pub use merge::merge_branch;
+//pub use status::get_repo_status;

--- a/src/git/status.rs
+++ b/src/git/status.rs
@@ -9,6 +9,14 @@ pub struct StatusEntry {
 }
 
 /// Get the status of files in the repository
+///
+/// # Arguments
+///
+/// * `repo` - A reference to the Git repository
+///
+/// # Returns
+///
+/// * `Result<Vec<StatusEntry>>` - Returns a vector of StatusEntry, or an error if it fails
 pub fn get_repo_status(repo: &Repository) -> Result<Vec<StatusEntry>> {
     let mut status_opts = StatusOptions::new();
     status_opts.include_untracked(true);

--- a/src/git/status.rs
+++ b/src/git/status.rs
@@ -1,0 +1,35 @@
+use crate::error::{GitFlowError, Result};
+use git2::{Repository, Status, StatusOptions};
+
+/// StatusEntry represents a single file status from the repository
+#[derive(Debug)]
+pub struct StatusEntry {
+    pub path: String,
+    pub status: Status,
+}
+
+/// Get the status of files in the repository
+pub fn get_repo_status(repo: &Repository) -> Result<Vec<StatusEntry>> {
+    let mut status_opts = StatusOptions::new();
+    status_opts.include_untracked(true);
+    status_opts.recurse_untracked_dirs(true);
+    status_opts.include_unmodified(false);
+    status_opts.include_ignored(false);
+
+    let statuses = repo.statuses(Some(&mut status_opts))?;
+
+    let mut result = Vec::new();
+    for entry in statuses.iter() {
+        let path = entry
+            .path()
+            .map(String::from)
+            .ok_or_else(|| GitFlowError::Git(git2::Error::from_str("Invalid path")))?;
+
+        result.push(StatusEntry {
+            path,
+            status: entry.status(),
+        });
+    }
+
+    Ok(result)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,9 +2,10 @@ mod cli;
 mod commands;
 mod error;
 mod git;
+mod utils;
 
 use cli::Cli;
-use commands::create;
+use commands::{cascade, create};
 use error::Result;
 
 use clap::Parser;
@@ -31,7 +32,7 @@ fn main() {
 ///
 /// # Returns
 ///
-/// * `Result<(), Box<dyn std::error::Error>>` - Returns an empty Ok result on success, or an error on failure
+/// * `Result<()>` - Returns an empty Ok result on success, or an error on failure
 fn run(cli: cli::Cli) -> Result<()> {
     // Open the git repository located at the current directory
     let _repo = Repository::open(".")?;
@@ -39,7 +40,16 @@ fn run(cli: cli::Cli) -> Result<()> {
     // Handle the appropriate command based on the parsed CLI arguments
     match cli.command {
         cli::Commands::Create { name, parent } => {
-            create::handle_new_branch(&_repo, &name, parent.as_deref())?;
+            create::handle_new_branch(&_repo, &name, parent.as_deref()).map_err(|e| {
+                println!("Error: {}", e);
+                e
+            })?;
+        }
+        cli::Commands::Cascade { yes } => {
+            cascade::handle_cascade(&_repo, yes).map_err(|e| {
+                println!("Error: {}", e);
+                e
+            })?;
         }
     }
     Ok(())

--- a/src/utils/display.rs
+++ b/src/utils/display.rs
@@ -1,0 +1,12 @@
+use std::io::{self, Write};
+
+/// Prompt the user for confirmation with a yes/no question
+pub fn prompt_confirmation(message: &str) -> io::Result<bool> {
+    print!("{} [y/N]: ", message);
+    io::stdout().flush()?;
+
+    let mut input = String::new();
+    io::stdin().read_line(&mut input)?;
+
+    Ok(input.trim().to_lowercase() == "y")
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,0 +1,3 @@
+pub mod display;
+
+pub use display::prompt_confirmation;


### PR DESCRIPTION
add modules to
- git::{branch, merge, status} -> module to interact with git api to merge branch recursively
- utils::{logger, display}
- errors -> so there is consistent error formatting